### PR TITLE
fix: update Ruby SDK fee rate units from sat/byte to sat/KB

### DIFF
--- a/packages/runar-rb/lib/runar/sdk/calling.rb
+++ b/packages/runar-rb/lib/runar/sdk/calling.rb
@@ -29,7 +29,7 @@ module Runar
     # @param change_address [String] Base58Check address or 40-char hex pubkey hash for change
     # @param change_script [String] pre-built change script hex (overrides +change_address+)
     # @param additional_utxos [Array<Utxo>, nil] P2PKH UTXOs used to fund fees
-    # @param fee_rate [Integer] satoshis per byte (minimum 1)
+    # @param fee_rate [Integer] satoshis per kilobyte (minimum 1)
     # @param options [Hash, nil] optional extensions:
     #   - +:contract_outputs+ [Array<Hash>] each +{script:, satoshis:}+ for multi-output
     #   - +:additional_contract_inputs+ [Array<Hash>] each +{utxo:, unlocking_script:}+
@@ -42,7 +42,7 @@ module Runar
       change_address,
       change_script = '',
       additional_utxos = nil,
-      fee_rate: 1,
+      fee_rate: 100,
       options: nil
     )
       opts                   = options || {}
@@ -91,7 +91,8 @@ module Runar
       outputs_size += P2PKH_OUTPUT_SIZE if has_change_recipient
 
       estimated_size = TX_OVERHEAD + inputs_size + outputs_size
-      fee            = estimated_size * [1, fee_rate].max
+      rate           = [1, fee_rate].max
+      fee            = (estimated_size * rate + 999) / 1000
       change         = total_input - contract_output_sats - fee
 
       # Build raw transaction bytes as a hex string.

--- a/packages/runar-rb/lib/runar/sdk/deployment.rb
+++ b/packages/runar-rb/lib/runar/sdk/deployment.rb
@@ -21,10 +21,10 @@ module Runar
     # @param satoshis [Integer] value to lock in the contract output
     # @param change_address [String] Base58Check address or 40-char hex pubkey hash for change
     # @param change_script [String] pre-built change script hex (overrides change_address when present)
-    # @param fee_rate [Integer] satoshis per byte (minimum 1)
+    # @param fee_rate [Integer] satoshis per kilobyte (minimum 1)
     # @return [Array(String, Integer)] [tx_hex, input_count]
     def build_deploy_transaction(locking_script, utxos, satoshis, change_address,
-                                 change_script = '', fee_rate: 1)
+                                 change_script = '', fee_rate: 100)
       raise ArgumentError, 'build_deploy_transaction: no UTXOs provided' if utxos.empty?
 
       total_input = utxos.sum(&:satoshis)
@@ -84,9 +84,9 @@ module Runar
     # @param utxos [Array<Utxo>] available UTXOs
     # @param target_satoshis [Integer] amount to place in the contract output
     # @param locking_script_byte_len [Integer] byte length of the locking script
-    # @param fee_rate [Integer] satoshis per byte
+    # @param fee_rate [Integer] satoshis per kilobyte
     # @return [Array<Utxo>]
-    def select_utxos(utxos, target_satoshis, locking_script_byte_len, fee_rate: 1)
+    def select_utxos(utxos, target_satoshis, locking_script_byte_len, fee_rate: 100)
       sorted   = utxos.sort_by { |u| -u.satoshis }
       selected = []
       total    = 0
@@ -110,14 +110,15 @@ module Runar
     #
     # @param num_inputs [Integer] number of inputs
     # @param locking_script_byte_len [Integer] byte length of the locking script
-    # @param fee_rate [Integer] satoshis per byte (minimum 1)
+    # @param fee_rate [Integer] satoshis per kilobyte (minimum 1)
     # @return [Integer] estimated fee in satoshis
-    def estimate_deploy_fee(num_inputs, locking_script_byte_len, fee_rate = 1)
+    def estimate_deploy_fee(num_inputs, locking_script_byte_len, fee_rate = 100)
       rate               = [1, fee_rate].max
       inputs_size        = num_inputs * P2PKH_INPUT_SIZE
       contract_out_size  = 8 + varint_byte_size(locking_script_byte_len) + locking_script_byte_len
       change_output_size = P2PKH_OUTPUT_SIZE
-      (TX_OVERHEAD + inputs_size + contract_out_size + change_output_size) * rate
+      tx_size            = TX_OVERHEAD + inputs_size + contract_out_size + change_output_size
+      (tx_size * rate + 999) / 1000
     end
 
     # Build a standard P2PKH locking script.

--- a/packages/runar-rb/lib/runar/sdk/provider.rb
+++ b/packages/runar-rb/lib/runar/sdk/provider.rb
@@ -46,7 +46,7 @@ module Runar
         raise NotImplementedError, "#{self.class}#get_network is not implemented"
       end
 
-      # Return the current fee rate in satoshis per byte.
+      # Return the current fee rate in satoshis per kilobyte.
       def get_fee_rate
         raise NotImplementedError, "#{self.class}#get_fee_rate is not implemented"
       end
@@ -61,7 +61,7 @@ module Runar
     #   provider.add_utxo('myAddress', Runar::SDK::Utxo.new(txid: 'abc...', ...))
     #   provider.get_utxos('myAddress') # => [<Utxo>]
     class MockProvider < Provider
-      DEFAULT_FEE_RATE = 1
+      DEFAULT_FEE_RATE = 100
 
       def initialize(network: 'testnet')
         @transactions     = {}
@@ -92,7 +92,7 @@ module Runar
         @contract_utxos[script_hash] = utxo
       end
 
-      # Override the fee rate (default: 1 sat/byte).
+      # Override the fee rate (default: 100 sat/KB).
       def set_fee_rate(rate)
         @fee_rate = rate
       end

--- a/packages/runar-rb/lib/runar/sdk/rpc_provider.rb
+++ b/packages/runar-rb/lib/runar/sdk/rpc_provider.rb
@@ -115,9 +115,9 @@ module Runar
         @network
       end
 
-      # Return fee rate in satoshis per byte.
+      # Return fee rate in satoshis per kilobyte.
       #
-      # Returns 1 sat/byte unconditionally — appropriate for regtest. For
+      # Returns 1 sat/KB unconditionally — appropriate for regtest. For
       # production networks, consider wrapping estimatesmartfee.
       #
       # @return [Integer]

--- a/packages/runar-rb/spec/sdk/deployment_spec.rb
+++ b/packages/runar-rb/spec/sdk/deployment_spec.rb
@@ -64,17 +64,16 @@ RSpec.describe 'Runar::SDK deployment helpers' do
       expect(fee).to be > 0
     end
 
-    it 'scales linearly with the number of inputs' do
+    it 'increases with the number of inputs' do
       fee1 = Runar::SDK.estimate_deploy_fee(1, LOCKING_BYTE_LEN)
       fee2 = Runar::SDK.estimate_deploy_fee(2, LOCKING_BYTE_LEN)
-      # Each extra input adds _P2PKH_INPUT_SIZE (148) bytes at fee_rate=1.
-      expect(fee2 - fee1).to eq(148)
+      expect(fee2).to be > fee1
     end
 
     it 'scales with fee_rate' do
-      fee1 = Runar::SDK.estimate_deploy_fee(1, LOCKING_BYTE_LEN, 1)
-      fee5 = Runar::SDK.estimate_deploy_fee(1, LOCKING_BYTE_LEN, 5)
-      expect(fee5).to eq(fee1 * 5)
+      fee_low  = Runar::SDK.estimate_deploy_fee(1, LOCKING_BYTE_LEN, 100)
+      fee_high = Runar::SDK.estimate_deploy_fee(1, LOCKING_BYTE_LEN, 1000)
+      expect(fee_high).to be > fee_low
     end
 
     it 'clamps fee_rate to a minimum of 1' do
@@ -83,9 +82,10 @@ RSpec.describe 'Runar::SDK deployment helpers' do
       expect(fee_zero).to eq(fee_one)
     end
 
-    it 'returns the known fee for 1 P2PKH-sized input' do
-      # overhead(10) + 1 input(148) + contract out(8+1+25=34) + change out(34) = 226
-      expect(Runar::SDK.estimate_deploy_fee(1, 25)).to eq(226)
+    it 'uses ceiling division for sat/KB calculation' do
+      # tx_size = overhead(10) + 1 input(148) + contract out(8+1+25=34) + change out(34) = 226
+      # fee = ceil(226 * 100 / 1000) = ceil(22.6) = 23
+      expect(Runar::SDK.estimate_deploy_fee(1, 25)).to eq(23)
     end
   end
 
@@ -117,7 +117,7 @@ RSpec.describe 'Runar::SDK deployment helpers' do
 
       # Each UTXO is tiny; we need all three plus fee coverage.
       # Target = 1 sat, but fee will dwarf it. All three together = 600 sats;
-      # that should be enough for a small target (fee ~226 sat at rate 1).
+      # that should be enough for a small target (fee ~52 sat at default rate).
       selected = Runar::SDK.select_utxos([utxo1, utxo2, utxo3], 1, LOCKING_BYTE_LEN)
       expect(selected.length).to be >= 1
     end
@@ -172,11 +172,10 @@ RSpec.describe 'Runar::SDK deployment helpers' do
 
     it 'produces a change output when excess funds are available' do
       tx_hex, = result
-      # Output count appears after version(8) + varint(2) + 1 input(~148*2 hex).
-      # Verify output count byte is 2 (change present).
-      # We check indirectly: the tx should be longer than without change.
+      # fee at default rate (100 sat/KB) for 1 input, 25-byte script = 23 sats
+      fee = Runar::SDK.estimate_deploy_fee(1, LOCKING_BYTE_LEN)
       tx_no_change, = Runar::SDK.build_deploy_transaction(
-        LOCKING_SCRIPT, [funding_utxo], 999_774, change_addr # fee ≈226, so change=0
+        LOCKING_SCRIPT, [funding_utxo], funding_utxo.satoshis - fee, change_addr
       )
       expect(tx_hex.length).to be > tx_no_change.length
     end

--- a/packages/runar-rb/spec/sdk/provider_spec.rb
+++ b/packages/runar-rb/spec/sdk/provider_spec.rb
@@ -52,8 +52,8 @@ RSpec.describe 'Runar::SDK::Provider' do
         expect(p.get_network).to eq('mainnet')
       end
 
-      it 'defaults fee rate to 1 sat/byte' do
-        expect(provider.get_fee_rate).to eq(1)
+      it 'defaults fee rate to 100 sat/KB' do
+        expect(provider.get_fee_rate).to eq(100)
       end
 
       it 'starts with no broadcasted transactions' do


### PR DESCRIPTION
## Summary
- Update `DEFAULT_FEE_RATE` from 1 (sat/byte) to 100 (sat/KB) in MockProvider
- Change fee calculation formula from `txSize * rate` to `ceil(txSize * rate / 1000)` in both `deployment.rb` and `calling.rb`
- Update all doc comments and tests to reflect sat/KB convention
- Matches the fee rate changes made to TS, Go, Rust, and Python SDKs in commit 2f0c936

## Test plan
- [x] All 601 Ruby SDK tests pass
- [x] Fee estimation tests updated with correct sat/KB expectations
- [x] Provider default fee rate test updated

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)