### PR TITLE
docs: fix stale Ruby documentation claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ All formats parse into the same `ContractNode` AST. From there, the pipeline is 
 | [Sha256CompressTest](examples/ts/sha256-compress/) | SHA-256 compression builtin | No | No |
 | [Sha256FinalizeTest](examples/ts/sha256-finalize/) | SHA-256 finalize builtin | No | No |
 
-All 21 examples are available in `ts/`, `go/`, `rust/`, `python/`, and `zig/`. 11 contracts are available in all 8 formats (TypeScript, Go, Rust, Ruby, Python, Zig, Solidity, Move). FunctionPatterns, PostQuantumWallet, SPHINCSWallet, SchnorrZKP, and ConvergenceProof are available in TypeScript, Go, Rust, Ruby, and Python. A 16-contract subset is also available in `sol/` and `move/`.
+All 21 examples are available in `ts/`, `go/`, `rust/`, `python/`, and `zig/`. 16 contracts are available in all 8 formats (TypeScript, Go, Rust, Ruby, Python, Zig, Solidity, Move). FunctionPatterns, PostQuantumWallet, SPHINCSWallet, SchnorrZKP, and ConvergenceProof are available in TypeScript, Go, Rust, Ruby, and Python.
 ```
 examples/
   ts/p2pkh/          P2PKH.runar.ts + P2PKH.test.ts
@@ -468,7 +468,7 @@ packages/
   runar-sdk/           # Deployment SDK (providers, signers)
   runar-cli/           # CLI tool
   runar-go/            # Go package: types, mock crypto, real hashes, CompileCheck(), deployment SDK
-  runar-rb/            # Ruby gem: types, DSL, mock crypto, real hashes, EC operations
+  runar-rb/            # Ruby gem: types, DSL, mock crypto, real hashes, EC operations, deployment SDK
   runar-rs/            # Rust crate: prelude types, mock crypto, real hashes, compile_check(), deployment SDK
   runar-rs-macros/     # Rust proc-macros (#[runar::contract], #[public], etc.)
   runar-py/            # Python package: types, mock crypto, real hashes, deployment SDK

--- a/packages/runar-rb/DESIGN.md
+++ b/packages/runar-rb/DESIGN.md
@@ -11,7 +11,7 @@
 Runar compiles a strict subset of several languages (TypeScript, Go, Rust, Solidity-like, Move-style, Python) into Bitcoin Script. All formats parse into the same `ContractNode` AST, after which the pipeline is identical. This document captures the rationale for adding Ruby as a supported format (`.runar.rb`).
 
 The implementation adds:
-- A hand-written parser (tokenizer + recursive descent) in all three compilers (TypeScript, Go, Rust)
+- A hand-written parser (tokenizer + recursive descent) in all four compilers (TypeScript, Go, Rust, Python)
 - A Ruby gem (`runar-rb`) providing base classes, types, mock crypto, and SDK
 - Example contracts, conformance tests, integration tests, and documentation
 


### PR DESCRIPTION
## Summary

- DESIGN.md: "three compilers" → "four compilers" (Python also has a Ruby parser)
- README: add "deployment SDK" to runar-rb project structure entry
- README: "11 contracts in all 8 formats" → 16 (stale after SHA-256 and other examples were added)

## Test plan

- [x] Documentation-only changes, no code affected

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)